### PR TITLE
Feature/verb grouping

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
         fi
         go install -v .
 
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.5.0
     - name: Run Kubernetes tests
       run: |
         kubectl cluster-info

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/coopernetes/kube-role-gen
 go 1.13
 
 require (
+	github.com/elliotchance/orderedmap v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elliotchance/orderedmap v1.3.0 h1:k6m77/d0zCXTjsk12nX40TkEBkSICq8T4s6R6bpCqU0=
+github.com/elliotchance/orderedmap v1.3.0/go.mod h1:8hdSl6jmveQw8ScByd3AaNHNk51RhbTazdqtTty+NFw=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
* group resources by their unique API group + supported verb pairs. This makes for easier authoring of RBAC roles when resources share a subset of verbs with other resources in the same API group. For example, the `pods` resource supports `[create delete deletecollection get list patch update watch]` but the `pods/log` only supports `[get`]. These now appear as separate policy rules in the generated role so that authors know that the `pods/log` cannot be given the `create` permission since its not supported.
* pulled in new dependency for maintaining the order of policies to match the API group's order from K8S discovery